### PR TITLE
adds vscan for initial and hardened image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 # The (optional) callable workflow to create the Vulnerability Scan Report 
 # of the unoptimized image produced by the "build" workflow. 
   
-  vuln-scan:
+  vulnerability-scan:
     needs: build
     uses: ./.github/workflows/vscan.yaml
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,3 +47,15 @@ jobs:
     secrets: inherit
     with:
       image: ${{ needs.build.outputs.image }}
+
+
+# The (optional) callable workflow to create the Vulnerability Scan Report 
+# of the unoptimized image produced by the "build" workflow. 
+  
+  vuln-scan:
+    needs: build
+    uses: ./.github/workflows/vscan.yaml
+    secrets: inherit
+    with:
+      image: ${{ needs.build.outputs.image }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,9 +49,8 @@ jobs:
       image: ${{ needs.build.outputs.image }}
 
 
-# The (optional) callable workflow to create the Vulnerability Scan Report 
-# of the unoptimized image produced by the "build" workflow. 
-  
+  # The (optional) callable workflow to create the Vulnerability Scan Report 
+  # of the unoptimized image produced by the "build" workflow. 
   vulnerability-scan:
     needs: build
     uses: ./.github/workflows/vscan.yaml

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -147,8 +147,8 @@ jobs:
         run: |
           docker stop app-hard
 
-# The (optional) callable workflow to create the Vulnerability Scan Report 
-# of the hardened image 
+  # The (optional) callable workflow to create the Vulnerability Scan Report 
+  # of the hardened image 
   vulnerability-scan:
     needs: harden
     uses: ./.github/workflows/vscan.yaml

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -51,6 +51,20 @@ jobs:
         with:
           token: ${{ secrets.SLIM_TOKEN }}
 
+      # Creates Vulnerability Scan Report for the Original Image and upload
+      # it as artifacts.          
+      - name: Create Vuln Scan Report for Original Image
+        run: |
+          export IMAGE=${{ inputs.image }}
+          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vuln-scan result for Original image
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-image-vuln-scan-report
+          path: report.txt
+          retention-days: 7
+  
       # Build the Instrumented image. When the instrument command is done,
       # the instrumented image will be available in the registry.
       #
@@ -123,6 +137,20 @@ jobs:
       - name: Harden the Target Image
         run: |
           slim harden --id ${{ needs.instrument.outputs.inst-id }}
+
+      # Creates Vulnerability Scan Report for Hardened Image and upload
+      # it as artifacts.          
+      - name: Create Vuln Scan Report for Hardened Image
+        run: |
+          export HARD_IMAGE=${{ needs.instrument.outputs.hard-image }}
+          NX_ID=$(slim workflows run --no-cache --image ${HARD_IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vuln-scan result for hardened image 
+        uses: actions/upload-artifact@v3
+        with:
+          name: hardened-image-vuln-scan-report
+          path: report.txt
+          retention-days: 7
 
   # The (optional) Verify stage: Run a container using the Hardened Image
   #                              and see if it's actually functional.

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -149,7 +149,7 @@ jobs:
 
 # The (optional) callable workflow to create the Vulnerability Scan Report 
 # of the hardened image 
-  vuln-scan:
+  vulnerability-scan:
     needs: harden
     uses: ./.github/workflows/vscan.yaml
     secrets: inherit

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -51,20 +51,6 @@ jobs:
         with:
           token: ${{ secrets.SLIM_TOKEN }}
 
-      # Creates Vulnerability Scan Report for the Original Image and upload
-      # it as artifacts.          
-      - name: Create Vuln Scan Report for Original Image
-        run: |
-          export IMAGE=${{ inputs.image }}
-          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
-          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vuln-scan result for Original image
-        uses: actions/upload-artifact@v3
-        with:
-          name: original-image-vuln-scan-report
-          path: report.txt
-          retention-days: 7
-  
       # Build the Instrumented image. When the instrument command is done,
       # the instrumented image will be available in the registry.
       #
@@ -138,20 +124,6 @@ jobs:
         run: |
           slim harden --id ${{ needs.instrument.outputs.inst-id }}
 
-      # Creates Vulnerability Scan Report for Hardened Image and upload
-      # it as artifacts.          
-      - name: Create Vuln Scan Report for Hardened Image
-        run: |
-          export HARD_IMAGE=${{ needs.instrument.outputs.hard-image }}
-          NX_ID=$(slim workflows run --no-cache --image ${HARD_IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
-          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vuln-scan result for hardened image 
-        uses: actions/upload-artifact@v3
-        with:
-          name: hardened-image-vuln-scan-report
-          path: report.txt
-          retention-days: 7
-
   # The (optional) Verify stage: Run a container using the Hardened Image
   #                              and see if it's actually functional.
   verify:
@@ -174,3 +146,12 @@ jobs:
       - name: Stop the Hardened Container
         run: |
           docker stop app-hard
+
+# The (optional) callable workflow to create the Vulnerability Scan Report 
+# of the hardened image 
+  vuln-scan:
+    needs: harden
+    uses: ./.github/workflows/vscan.yaml
+    secrets: inherit
+    with:
+      image: ${{ needs.instrument.outputs.hard-image }}

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -29,12 +29,12 @@ jobs:
 
       # Creates Vulnerability Scan Report for the input Image and upload
       # it as artifacts.          
-      - name: Create Vulnerability Scan Report for input Image
+      - name: Trigger multi-scanner pass for the Image (using the Slim.AI infrastructure)
         run: |
           export IMAGE=${{ inputs.image }}
           NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
           slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vulnerability scan result for the image
+      - name: Save the Vulnerability Scanning results as an artifact for future reference.
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.image }}-vuln-scan-report

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -1,0 +1,42 @@
+# A workflow to create the Vulnerability Scan Report of the input image 
+# that may be (unoptimized) version of the image initally built
+# or the hardened image.
+#
+# The current workflow:
+#  - Installs slimctl.
+#  - Creates the Vulnerability Scan Report of the input image
+
+name: vuln-scan
+on:
+  workflow_call:
+    inputs:
+      # The image whose vuln scan report will be created.
+      image:
+        required: true
+        type: string
+
+jobs:
+  vuln-scan-report:
+    runs-on: ubuntu-latest
+    steps:
+      # TMP WORKAROUND: Until the slimctl action is published.
+      - uses: actions/checkout@v3
+
+      # Install and configure the slimctl CLI.
+      - uses: ./.github/actions/slimctl
+        with:
+          token: ${{ secrets.SLIM_TOKEN }}
+
+      # Creates Vulnerability Scan Report for the Original Image and upload
+      # it as artifacts.          
+      - name: Create Vuln Scan Report for input Image
+        run: |
+          export IMAGE=${{ inputs.image }}
+          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vuln-scan result for the image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.image }}-vuln-scan-report
+          path: report.txt
+          retention-days: 7

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -6,17 +6,17 @@
 #  - Installs slimctl.
 #  - Creates the Vulnerability Scan Report of the input image
 
-name: vuln-scan
+name: vulnerability-scan
 on:
   workflow_call:
     inputs:
-      # The image whose vuln scan report will be created.
+      # The image whose Vulnerability scan report will be created.
       image:
         required: true
         type: string
 
 jobs:
-  vuln-scan-report:
+  vulnerability-scan-report:
     runs-on: ubuntu-latest
     steps:
       # TMP WORKAROUND: Until the slimctl action is published.
@@ -27,14 +27,14 @@ jobs:
         with:
           token: ${{ secrets.SLIM_TOKEN }}
 
-      # Creates Vulnerability Scan Report for the Original Image and upload
+      # Creates Vulnerability Scan Report for the input Image and upload
       # it as artifacts.          
-      - name: Create Vuln Scan Report for input Image
+      - name: Create Vulnerability Scan Report for input Image
         run: |
           export IMAGE=${{ inputs.image }}
           NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
           slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vuln-scan result for the image
+      - name: Upload vulnerability scan result for the image
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.image }}-vuln-scan-report

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -16,7 +16,7 @@ on:
         type: string
 
 jobs:
-  vulnerability-scan-report:
+  vulnerability-scan:
     runs-on: ubuntu-latest
     steps:
       # TMP WORKAROUND: Until the slimctl action is published.


### PR DESCRIPTION
Adds vuln scan report to the workflow for both hardened and original image with retention period of 7 days. This is how I tested in separate repo https://github.com/mritunjaysharma394/ich-k8s-example/actions/runs/4230143189